### PR TITLE
Increase memory

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -39,7 +39,7 @@ Resources:
       Description: Splits s3 files into smaller parts
       Runtime: nodejs8.10
       Handler: lambda.handler
-      MemorySize: 128
+      MemorySize: 512
       Timeout: 300
       Environment:
         Variables:


### PR DESCRIPTION
In the [previous PR](https://github.com/guardian/s3-chunking-lambda/pull/3) I boldly claimed that we have plenty of memory to spare.
It can now run out of memory while streaming (very) large acast log files