### PR TITLE
Bump aws-sdk version

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "node": ">=20.9.0"
   },
   "dependencies": {
-    "aws-sdk": "^2.950.0"
+    "aws-sdk": "^2.953.0"
   },
   "devDependencies": {
     "@types/node": "^16.4.0",

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -4,8 +4,17 @@ regions: [eu-west-1]
 deployments:
   s3-chunking-lambda:
     type: aws-lambda
+    dependencies: [cloudformation]
     parameters:
       prefixStack: false
       bucketSsmLookup: true
       fileName: s3-chunking-lambda.zip
       functionNames: [s3-chunking-lambda-]
+  cloudformation:
+    type: cloud-formation
+    app: s3-chunking-lambda
+    parameters:
+      prependStackToCloudFormationStackName: false
+      cloudFormationStackName: s3-chunking-lambda
+      templatePath: cloudformation.yaml
+      cloudFormationStackByTags: false


### PR DESCRIPTION
## What does this change?
The previous PR failed to update the node runtime to v20.

This PR attempts to fix this by bumping the aws-sdk package to a minimum version that has worked in other repos

Also looks like we need to add cloudformation instructions to the riff-raff file to get the branch to actually update (rather than do it manually in the AWS console)

## How to test
Testing is the same as described in PR https://github.com/guardian/s3-chunking-lambda/pull/21
